### PR TITLE
README and stats gather fixments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,12 +14,11 @@ Install it with pip (or easy_install, if that's how you roll)::
 
 In your project settings::
 
-    MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + ('django-plop.middleware.PlopMiddleware',)
+    MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + ('django_plop.middleware.PlopMiddleware',)
 
     PLOP_DIR = os.path.join(PROJECT_ROOT, 'plop') # will be created, defaults to /tmp/plop
 
-Then start your server with ``python manage.py --noreload`` (the ``--noreload``
-is very important.) Hit a few pages, and then start the plop viewer like so::
+Then start your server with ``python manage.py --noreload --nothreading`` (the ``--noreload --nothreading`` are very important.) Hit a few pages, and then start the plop viewer like so::
 
     python -m plop.viewer --datadir=plop
 

--- a/django_plop/middleware.py
+++ b/django_plop/middleware.py
@@ -30,8 +30,9 @@ class PlopMiddleware(object):
         'after the view executes, stop profiling'
         if hasattr(request, 'collector'): # 404s
             request.collector.stop()
-            with open(request.plop_filename, 'a') as plop_file:
-                plop_file.write(repr(dict(request.collector.stack_counts)))
+            if request.collector.samples_taken:
+                with open(request.plop_filename, 'w') as plop_file:
+                    plop_file.write(repr(dict(request.collector.stack_counts)))
 
         return response
 

--- a/django_plop/middleware.py
+++ b/django_plop/middleware.py
@@ -22,9 +22,10 @@ class PlopMiddleware(object):
 
     def process_view(self, request, view_func, _, __):
         'process a single view, adding the collector'
-        request.collector = Collector()
-        request.collector.start()
-        request.plop_filename = self.get_filename(view_func)
+        if hasattr(view_func, '__name__'):
+            request.collector = Collector()
+            request.collector.start()
+            request.plop_filename = self.get_filename(view_func)
 
     def process_response(self, request, response):
         'after the view executes, stop profiling'


### PR DESCRIPTION
fix: django-plop README.rst usage
fix: stack_counts file write when collector instance run was slower than whole request exec
